### PR TITLE
Dart Docker image now a variable in deploy scripts

### DIFF
--- a/deploy.ps1
+++ b/deploy.ps1
@@ -5,6 +5,7 @@ $FUNCTION_HANDLER='hello.method'
 
 $DOCKER_IMAGE_NAME='dart-lambda-builder-x64'
 $DOCKERFILE_NAME='dockerfile'
+$DART_IMAGE='dart'
 
 function Get-ContainerId {
     return $(docker ps --all --filter ancestor=${DOCKER_IMAGE_NAME} --latest --format '{{.ID}}')
@@ -27,7 +28,7 @@ if ([string]::IsNullOrEmpty(${CONTAINER_ID})) {
 }
 
 Write-Output "Building Docker Image..."
-docker build . -t ${DOCKER_IMAGE_NAME} -f ${DOCKERFILE_NAME} --build-arg dart
+docker build . -t ${DOCKER_IMAGE_NAME} -f ${DOCKERFILE_NAME} --build-arg ${DART_IMAGE}
 Write-Output "Running Docker Container..."
 docker run -d ${DOCKER_IMAGE_NAME}
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -5,6 +5,7 @@ FUNCTION_HANDLER='hello.method'
 
 DOCKER_IMAGE_NAME='dart-lambda-builder-arm64'
 DOCKERFILE_NAME='macos-arm-dockerfile'
+DART_IMAGE='arm64v8/dart'
 
 # Cleaning up Docker container
 CONTAINER_ID=$(docker ps -all --filter ancestor=${DOCKER_IMAGE_NAME} --latest --format '{{.ID}}')
@@ -20,7 +21,7 @@ else
 fi
 
 echo "Building Docker Image..."
-docker build . -t ${DOCKER_IMAGE_NAME} -f ./${DOCKERFILE_NAME} --build-arg arm64v8/dart
+docker build . -t ${DOCKER_IMAGE_NAME} -f ./${DOCKERFILE_NAME} --build-arg ${DART_IMAGE}
 echo "Running Docker Container..."
 docker run -d ${DOCKER_IMAGE_NAME}
 


### PR DESCRIPTION
Moved the Dart Docker Image name out of the explicit Docker Build command and into the deployment scripts variables. This will help those that need to change what the images are if their use-case requires it.